### PR TITLE
Sixth Query

### DIFF
--- a/8_macro_expressions.ql
+++ b/8_macro_expressions.ql
@@ -1,1 +1,5 @@
+import cpp
 
+from MacroInvocation mi
+where mi.getMacro().getName().regexpMatch("ntoh(s|l|ll)")
+select mi.getExpr()


### PR DESCRIPTION
import cpp

from MacroInvocation mi
where mi.getMacro().getName().regexpMatch("ntoh(s|l|ll)")
select mi.getExpr()