### PR TITLE
Ninth Query

### DIFF
--- a/9_class_network_byteswap.ql
+++ b/9_class_network_byteswap.ql
@@ -1,1 +1,13 @@
+import cpp
 
+class NetworkByteSwap extends Expr {
+  NetworkByteSwap() {
+    exists(MacroInvocation mi |
+      mi.getMacroName().regexpMatch("ntoh(s|l|ll)") and
+      this = mi.getExpr()
+    )
+  }
+}
+
+from NetworkByteSwap n
+select n


### PR DESCRIPTION
import cpp

class NetworkByteSwap extends Expr {
  NetworkByteSwap() {
    exists(MacroInvocation mi |
      mi.getMacroName().regexpMatch("ntoh(s|l|ll)") and
      this = mi.getExpr()
    )
  }
}

from NetworkByteSwap n
select n